### PR TITLE
Heroku needs package.lock to verify pkgs version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -41277,6 +41277,14 @@
         "prop-types": "^15.6.1"
       }
     },
+    "react-iframe": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/react-iframe/-/react-iframe-1.8.0.tgz",
+      "integrity": "sha512-NYi89+rEqREwQxW9sDf+akh6/dtwWd3bOjByoVEIQ7SicOxVawRMer3pLdWjFaHXpuxTB9NqobPf/Ohj2iAKkg==",
+      "requires": {
+        "object-assign": "^4.1.1"
+      }
+    },
     "react-image-magnifiers": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/react-image-magnifiers/-/react-image-magnifiers-1.4.0.tgz",


### PR DESCRIPTION
Previous PR was missing package-lock.json and heroku needs this file to verify pkgs version.